### PR TITLE
removed dependence on old-locale (System.Locale)

### DIFF
--- a/NotmuchTest.hs
+++ b/NotmuchTest.hs
@@ -13,7 +13,6 @@
 import Control.Monad
 import Data.Time
 import System.Environment
-import System.Locale
     
 import Foreign.Notmuch
 

--- a/notmuch-haskell.cabal
+++ b/notmuch-haskell.cabal
@@ -1,5 +1,5 @@
 Name: notmuch-haskell
-Version: 1.0.0.3
+Version: 1.0.0.4
 Cabal-Version: >= 1.6
 Author: Bart Massey <bart@cs.pdx.edu>
 Maintainer: Bart Massey <bart@cs.pdx.edu>
@@ -26,7 +26,7 @@ Library
 Executable notmuch-test
   main-is: NotmuchTest.hs
   other-modules: Foreign.Notmuch Foreign.NOTMUCH_H
-  build-depends: base >= 4.5 && < 6, old-locale >= 1 && < 2,
+  build-depends: base >= 4.5 && < 6,
                  parseargs >= 0.1.3 && < 2
   Extra-Libraries: notmuch
   GHC-Options: -Wall


### PR DESCRIPTION
`defaultTimeLocale` is now defined in `Data.Time`. So I got a build failure because both definitions were imported. The patch fixes this: Now the definition from `Data.Time` is used.